### PR TITLE
Configure google client via runtime

### DIFF
--- a/app/nuxt.config.ts
+++ b/app/nuxt.config.ts
@@ -12,6 +12,9 @@ export default defineNuxtConfig({
     // Public keys (exposed to client-side)
     public: {
       apiBaseUrl: process.env.NUXT_PUBLIC_API_BASE_URL || 'http://localhost:5157',
+      googleClientId:
+        process.env.NUXT_PUBLIC_GOOGLE_CLIENT_ID ||
+        '715368478743-4vugo0hso9hmgouvepovj9jm56tkoutp.apps.googleusercontent.com'
     }
   },
   app: {

--- a/app/pages/auth/login.vue
+++ b/app/pages/auth/login.vue
@@ -105,6 +105,7 @@ const error = ref('')
 const loading = ref(false)
 
 const authStore = useAuthStore()
+const runtimeConfig = useRuntimeConfig()
 
 const handleLogin = async () => {
   error.value = ''
@@ -169,7 +170,7 @@ onMounted(() => {
   script.onload = () => {
     // Initialize and render the button
     window.google.accounts.id.initialize({
-      client_id: '715368478743-4vugo0hso9hmgouvepovj9jm56tkoutp.apps.googleusercontent.com',
+      client_id: runtimeConfig.public.googleClientId,
       callback: handleGoogleCallback,
       auto_select: false,
       cancel_on_tap_outside: true

--- a/app/pages/auth/register.vue
+++ b/app/pages/auth/register.vue
@@ -173,6 +173,7 @@ const error = ref('')
 const loading = ref(false)
 
 const authStore = useAuthStore()
+const runtimeConfig = useRuntimeConfig()
 
 const handleRegister = async () => {
   error.value = ''
@@ -254,7 +255,7 @@ onMounted(() => {
   script.onload = () => {
     // Initialize and render the button
     window.google.accounts.id.initialize({
-      client_id: '715368478743-4vugo0hso9hmgouvepovj9jm56tkoutp.apps.googleusercontent.com',
+      client_id: runtimeConfig.public.googleClientId,
       callback: handleGoogleCallback,
       auto_select: false,
       cancel_on_tap_outside: true


### PR DESCRIPTION
## Summary
- load the Google OAuth client ID from Nuxt runtime config so production builds can use Netlify env vars
- update the login and register pages to initialize Google Identity with the runtime-configured client ID
- keep the current client ID as a fallback for local development

## Testing
- npm run build